### PR TITLE
Fix for malfunctioning exponential backoff retry mechanism

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -173,7 +173,7 @@
         } else if (response.statusCode >= 200 && response.statusCode < 300) {
           return cb(error, response, body);
         } else {
-          if ((response.statusCode === 503 || response.statusCode === 408) && retry < this.MAX_RETRIES) {
+          if ((response.statusCode === 503 || response.statusCode === 408) && retry < MAX_RETRIES) {
             delay = Math.pow(4, retry) * 100 * Math.random();
             return _.delay(requestBind, delay, requestInfo, cb, retry + 1);
           } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iron_core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Core library for Iron products",
   "homepage": "https://github.com/iron-io/iron_core_node",
   "author": "Andrew Kirilenko & Iron.io, Inc",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -117,7 +117,7 @@ class Client
       else if response.statusCode >= 200 and response.statusCode < 300
         cb(error, response, body)
       else
-        if (response.statusCode == 503 or response.statusCode == 408) and retry < @MAX_RETRIES
+        if (response.statusCode == 503 or response.statusCode == 408) and retry < MAX_RETRIES
           delay = Math.pow(4, retry) * 100 * Math.random()
           _.delay(requestBind, delay, requestInfo, cb, retry + 1)
         else


### PR DESCRIPTION
There is an epic bug in the retry mechanism of requests, which causes it not to work, it just makes one request and returns final error to anyone using this function. 
There has been a mixup in the scopes of the variable MAX_RETRIES, which this pull request solves.
If you merge this in, please make a new release for this library and the iron_mq_node library (v2 branch).